### PR TITLE
Update __main__.py

### DIFF
--- a/src/darwinio/__main__.py
+++ b/src/darwinio/__main__.py
@@ -45,9 +45,10 @@ def main(resolution: tuple[int, int], fps: int, world_size: tuple[int, int]):
     # music
     music_playing = True
     with gsim.get_asset_path("audio", "Darwinio.mp3") as path:
+        pg.init()
         pg.mixer.music.load(path)
-    pg.mixer.music.set_volume(1)
-    pg.mixer.music.play()
+        pg.mixer.music.set_volume(1)
+        pg.mixer.music.play()
 
     world = gsim.World(world_size)
 


### PR DESCRIPTION
there was a issue of initializing pygame mixer check it and rectify

**ERROR COPY START**
pygame-ce 2.3.0 (SDL 2.26.4, Python 3.10.8)
ALSA lib confmisc.c:767:(parse_card) cannot find card '0'
ALSA lib conf.c:4732:(_snd_config_evaluate) function snd_func_card_driver returned error: No such file or directory
ALSA lib confmisc.c:392:(snd_func_concat) error evaluating strings
ALSA lib conf.c:4732:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1246:(snd_func_refer) error evaluating name
ALSA lib conf.c:4732:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5220:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM default
/workspaces/darwinio/.venv/lib/python3.10/site-packages/darwinio/__main__.py:39: Warning: no fast renderer available
  screen = pg.display.set_mode(resolution, pg.SCALED | pg.RESIZABLE)
Traceback (most recent call last):
  File "/usr/local/python/3.10.8/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/python/3.10.8/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/workspaces/darwinio/.venv/lib/python3.10/site-packages/darwinio/__main__.py", line 97, in <module>
    main((1000, 750), 60, (50, 50))
  File "/workspaces/darwinio/.venv/lib/python3.10/site-packages/darwinio/__main__.py", line 48, in main
    pg.mixer.music.load(path)
pygame.error: mixer not initialized

**ERROR COPY END**

