### PR TITLE
typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ organisms, genetic codes, and neural networks.
     ```
    ## For ArchLinux and it's derivatives
     ```
-    pacman -S pipx 
+    pacman -S python-pipx 
     
     ```
    ## For Gentoo

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ organisms, genetic codes, and neural networks.
     ```
    ## For ArchLinux and it's derivatives
     ```
-    pacman -S python-pipx 
+    pacman -S python-pipx
     
     ```
    ## For Gentoo


### PR DESCRIPTION
'pacman -S pipx' should be 'pacman -S python-pipx' and also there's a space after pipx you wrote which can cause error